### PR TITLE
fix(Vercel): separate authOptions into another file

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,78 +1,8 @@
+import { authOptions } from "@/config/authOptions";
 import NextAuth, { User } from "next-auth";
 // import GitHubProvider from "next-auth/providers/github";
-import CredentialsProvider from "next-auth/providers/credentials";
-import { JWT } from "next-auth/jwt";
-import { Session } from "next-auth";
 import { AdapterUser } from "next-auth/adapters";
 
-export const authOptions = {
-  providers: [
-    // GitHubProvider({
-    //   clientId: process.env.GITHUB_ID ?? "",
-    //   clientSecret: process.env.GITHUB_SECRET ?? "",
-    // }),
-
-    CredentialsProvider({
-      type: "credentials",
-      credentials: {},
-      async authorize(credentials, req) {
-        const { email, ethSignProof, walletId } = credentials as {
-          email: string;
-          ethSignProof: string;
-          walletId: string;
-        };
-
-        if (
-          email == undefined ||
-          ethSignProof == undefined ||
-          walletId == undefined
-        ) {
-          return null;
-        }
-
-        const user = {
-          id: walletId,
-          email: email,
-          ethSignProof: ethSignProof,
-          walletId: walletId,
-        };
-
-        return user;
-      },
-    }),
-  ],
-  callbacks: {
-    // TODO: Update types of destructured objects
-    // async jwt({ token, user, session }: {token: JWT, user: AdapterUser, session: Session}): Promise<JWT> { // yelling
-    // async jwt({ token, user, session }: {token: JWT, user: any, session: Session}): Promise<JWT> { // yelling
-    async jwt({ token, user, session }: any): Promise<JWT> {
-      console.log("jwt here", { token, user, session });
-
-      if (user) {
-        return {
-          ...token,
-          walletId: user.walletId,
-          ethSignProof: user.ethSignProof,
-        };
-      }
-
-      return token;
-    },
-    async session({ session, token, user }: any): Promise<Session> {
-      console.log("session callback", { session, token, user });
-
-      return {
-        ...session,
-        user: {
-          ...session.user,
-          ethSignProof: token.ethSignProof,
-          walletId: token.walletId,
-        },
-      };
-    },
-  },
-};
-
-export const handler = NextAuth(authOptions);
+const handler = NextAuth(authOptions);
 
 export { handler as GET, handler as POST };

--- a/src/app/api/whoAmI/route.ts
+++ b/src/app/api/whoAmI/route.ts
@@ -1,7 +1,6 @@
+import { authOptions } from "@/config/authOptions";
 import { getServerSession } from "next-auth";
 import { NextResponse } from "next/server";
-
-import { authOptions } from "../auth/[...nextauth]/route";
 
 export async function GET() {
   const session = await getServerSession(authOptions);

--- a/src/config/authOptions.ts
+++ b/src/config/authOptions.ts
@@ -1,0 +1,72 @@
+// import GitHubProvider from "next-auth/providers/github";
+import CredentialsProvider from "next-auth/providers/credentials";
+import { JWT } from "next-auth/jwt";
+import { Session } from "next-auth";
+
+export const authOptions = {
+  providers: [
+    // GitHubProvider({
+    //   clientId: process.env.GITHUB_ID ?? "",
+    //   clientSecret: process.env.GITHUB_SECRET ?? "",
+    // }),
+
+    CredentialsProvider({
+      type: "credentials",
+      credentials: {},
+      async authorize(credentials, req) {
+        const { email, ethSignProof, walletId } = credentials as {
+          email: string;
+          ethSignProof: string;
+          walletId: string;
+        };
+
+        if (
+          email == undefined ||
+          ethSignProof == undefined ||
+          walletId == undefined
+        ) {
+          return null;
+        }
+
+        const user = {
+          id: walletId,
+          email: email,
+          ethSignProof: ethSignProof,
+          walletId: walletId,
+        };
+
+        return user;
+      },
+    }),
+  ],
+  callbacks: {
+    // TODO: Update types of destructured objects
+    // async jwt({ token, user, session }: {token: JWT, user: AdapterUser, session: Session}): Promise<JWT> { // yelling
+    // async jwt({ token, user, session }: {token: JWT, user: any, session: Session}): Promise<JWT> { // yelling
+    async jwt({ token, user, session }: any): Promise<JWT> {
+      console.log("jwt here", { token, user, session });
+
+      if (user) {
+        return {
+          ...token,
+          walletId: user.walletId,
+          ethSignProof: user.ethSignProof,
+        };
+      }
+
+      return token;
+    },
+    async session({ session, token, user }: any): Promise<Session> {
+      console.log("session callback", { session, token, user });
+
+      return {
+        ...session,
+        user: {
+          ...session.user,
+          ethSignProof: token.ethSignProof,
+          walletId: token.walletId,
+        },
+      };
+    },
+  },
+};


### PR DESCRIPTION
## Describe your changes
- Separate authOptions into another files
- Remove "export" keywords from the handler
- To support the changes above, see more at [This is because you are only allowed to export HTTP Methods (GET, HEAD, POST, PUT, DELETE, etc).](https://stackoverflow.com/a/76811464). Otherwise, it may have some problems to be built and deployed on Vercel.


## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.